### PR TITLE
complete path for scif install inside Docker image

### DIFF
--- a/tutorials/preview-install.md
+++ b/tutorials/preview-install.md
@@ -334,7 +334,7 @@ First we will do it interactively, and then add a few lines to a recipe to do it
 ```
 $ docker run -v $PWD:/tmp -it continuumio/miniconda3 /bin/bash
 $ pip install scif
-$ scif install hello-world.scif
+$ scif install /tmp/hello-world.scif
 Installing base at /scif
 + apprun hello-world-echo
 + appenv hello-world-echo


### PR DESCRIPTION
I found that without the absolute path, 
```python
scif install hello-world.scif
```
raises

> ERROR Cannot find recipe file hello-world.scif

but with `scif install /tmp/hello-world.scif`, I get the behaviour described in the tutorial.